### PR TITLE
add end to end test for liquid-vault

### DIFF
--- a/test/liquid-vault.js
+++ b/test/liquid-vault.js
@@ -438,8 +438,6 @@ describe('LiquidVault', function () {
 
     const ethUserBalanceBeforeRemoveLiquidity = await ethers.provider.getBalance(user.address);
 
-    assert.notEqual(await uniswapPair.balanceOf(user.address), 0);
-
     await uniswapPair.connect(user).approve(uniswapRouter.address, lpBalanceAfterClaim);
     await expect(uniswapRouter.connect(user).removeLiquidityETH(
       infinity.address, 

--- a/test/liquid-vault.js
+++ b/test/liquid-vault.js
@@ -364,8 +364,8 @@ describe('LiquidVault', function () {
     assertBNequal(exitFee, estimatedFeeAmount);
     assertBNequal(amount.sub(exitFee), lpBalanceAfterClaim.sub(lpBalanceBeforeClaim));
 
-    infinityBalanceBefore = await infinity.balanceOf(accounts[0].address)
-    wethBalanceBefore = await weth.balanceOf(accounts[0].address)
+    infinityBalanceBefore = await infinity.balanceOf(owner.address)
+    wethBalanceBefore = await weth.balanceOf(owner.address)
 
     await uniswapPair.approve(uniswapRouter.address, lpBalanceAfterClaim)
     await expect(uniswapRouter.removeLiquidity(
@@ -378,8 +378,8 @@ describe('LiquidVault', function () {
       new Date().getTime() + 3000, // uint deadline
     )).to.emit(uniswapPair, 'Burn')
 
-    infinityBalanceAfter = await infinity.balanceOf(accounts[0].address)
-    wethBalanceAfter = await weth.balanceOf(accounts[0].address)
+    infinityBalanceAfter = await infinity.balanceOf(owner.address)
+    wethBalanceAfter = await weth.balanceOf(owner.address)
 
     assert.isTrue(wethBalanceAfter.gt(wethBalanceBefore))
     assert.isTrue(infinityBalanceAfter.gt(infinityBalanceBefore))

--- a/test/liquid-vault.js
+++ b/test/liquid-vault.js
@@ -386,7 +386,7 @@ describe('LiquidVault', function () {
 
     const lpBalanceAfterRemoveLiquidity = await uniswapPair.balanceOf(owner.address);
 
-    assertBNequal(lpBalanceAfterRemoveLiUserquidity);
+    assertBNequal(lpBalanceAfterRemoveLiquidity);
   });
 
   it('should be able to claim 1 batch after 1 purchase with 0% fees then transfer lptokens to another user and remove eth liquidity from uniswap', async function() {
@@ -416,16 +416,14 @@ describe('LiquidVault', function () {
     assertBNequal(exitFee, estimatedFeeAmount);
     assertBNequal(amount.sub(exitFee), lpBalanceAfterClaim.sub(lpBalanceBeforeClaim));
 
-    uniswapPairUserBalanceBefore = await uniswapPair.balanceOf(user.address);
-    uniswapPairOwnerBalanceBefore = await uniswapPair.balanceOf(owner.address);
+    const value = bn('3361501152757987');
+
+    assertBNequal(await uniswapPair.balanceOf(owner.address), value);
 
     await uniswapPair.transfer(user.address, lpBalanceAfterClaim);
 
-    uniswapPairUserBalanceAfter = await uniswapPair.balanceOf(user.address);
-    uniswapPairOwnerBalanceAfter = await uniswapPair.balanceOf(owner.address);
-
-    assertBNequal(uniswapPairUserBalanceBefore, 0);
-    assertBNequal(uniswapPairOwnerBalanceAfter, 0);
+    assertBNequal(await uniswapPair.balanceOf(user.address), value);
+    assertBNequal(await uniswapPair.balanceOf(owner.address), 0);
 
     await uniswapPair.approve(uniswapRouter.address, lpBalanceAfterClaim);
     await expect(uniswapRouter.removeLiquidity(
@@ -438,8 +436,9 @@ describe('LiquidVault', function () {
       new Date().getTime() + 3000,
     )).to.be.revertedWith('revert ds-math-sub-underflow');
 
-    const infinityBalanceBefore = await infinity.balanceOf(user.address);
-    const ethUserBalanceBefore = await ethers.provider.getBalance(user.address);
+    const ethUserBalanceBeforeRemoveLiquidity = await ethers.provider.getBalance(user.address);
+
+    assert.notEqual(await uniswapPair.balanceOf(user.address), 0);
 
     await uniswapPair.connect(user).approve(uniswapRouter.address, lpBalanceAfterClaim);
     await expect(uniswapRouter.connect(user).removeLiquidityETH(
@@ -451,15 +450,10 @@ describe('LiquidVault', function () {
       new Date().getTime() + 3000,
     )).to.emit(uniswapPair, 'Burn');
 
-    const infinityBalanceAfter = await infinity.balanceOf(owner.address);
-    const ethUserBalanceAfter = await ethers.provider.getBalance(user.address);
+    const ethUserBalanceAfterRemoveLiquidity = await ethers.provider.getBalance(user.address);
     
-    assert.isTrue(infinityBalanceAfter.gt(infinityBalanceBefore));
-    assert.isTrue(ethUserBalanceAfter.gt(ethUserBalanceBefore));
-
-    const lpBalanceAfterRemoveLiquidity = await uniswapPair.balanceOf(owner.address);
-
-    assertBNequal(lpBalanceAfterRemoveLiquidity, 0);
+    assertBNequal(await uniswapPair.balanceOf(user.address), 0);
+    assert.isTrue(ethUserBalanceAfterRemoveLiquidity.gt(ethUserBalanceBeforeRemoveLiquidity)); 
   });
 
   //TODO: add tests for the force unlock and for token with fees

--- a/test/liquid-vault.js
+++ b/test/liquid-vault.js
@@ -364,10 +364,10 @@ describe('LiquidVault', function () {
     assertBNequal(exitFee, estimatedFeeAmount);
     assertBNequal(amount.sub(exitFee), lpBalanceAfterClaim.sub(lpBalanceBeforeClaim));
 
-    infinityBalanceBefore = await infinity.balanceOf(owner.address)
-    wethBalanceBefore = await weth.balanceOf(owner.address)
+    infinityBalanceBefore = await infinity.balanceOf(owner.address);
+    wethBalanceBefore = await weth.balanceOf(owner.address);
 
-    await uniswapPair.approve(uniswapRouter.address, lpBalanceAfterClaim)
+    await uniswapPair.approve(uniswapRouter.address, lpBalanceAfterClaim);
     await expect(uniswapRouter.removeLiquidity(
       infinity.address, // address tokenA
       weth.address, //address tokenB
@@ -378,16 +378,88 @@ describe('LiquidVault', function () {
       new Date().getTime() + 3000, // uint deadline
     )).to.emit(uniswapPair, 'Burn')
 
-    infinityBalanceAfter = await infinity.balanceOf(owner.address)
-    wethBalanceAfter = await weth.balanceOf(owner.address)
+    infinityBalanceAfter = await infinity.balanceOf(owner.address);
+    wethBalanceAfter = await weth.balanceOf(owner.address);
 
-    assert.isTrue(wethBalanceAfter.gt(wethBalanceBefore))
-    assert.isTrue(infinityBalanceAfter.gt(infinityBalanceBefore))
+    assert.isTrue(wethBalanceAfter.gt(wethBalanceBefore));
+    assert.isTrue(infinityBalanceAfter.gt(infinityBalanceBefore));
 
     const lpBalanceAfterRemoveLiquidity = await uniswapPair.balanceOf(owner.address);
 
-    assertBNequal(lpBalanceAfterRemoveLiquidity, 0)
+    assertBNequal(lpBalanceAfterRemoveLiUserquidity);
+  });
 
+  it('should be able to claim 1 batch after 1 purchase with 0% fees then transfer lptokens to another user and remove eth liquidity from uniswap', async function() {
+    const purchaseValue = utils.parseEther('1');
+    const transferToLiquidVault = utils.parseUnits('20000', baseUnit); // 20.000 tokens
+
+    await infinity.transfer(liquidVault.address, transferToLiquidVault);
+    assertBNequal(await infinity.balanceOf(liquidVault.address), transferToLiquidVault);
+    
+    await liquidVault.purchaseLP({ value: purchaseValue });
+    const lockedLP = await liquidVault.getLockedLP(owner.address, 0);
+    const { donationShare } = await liquidVault.config();
+    const stakeDuration = await liquidVault.getStakeDuration();
+    const lpBalanceBeforeClaim = await uniswapPair.balanceOf(owner.address);
+
+    await ganache.setTime((bn(lockedLP[2]).add(stakeDuration)).toNumber());
+    const claimLP = await liquidVault.claimLP();
+    const receipt = await claimLP.wait();
+
+    const { holder, amount, exitFee, claimed } = receipt.events[0].args;
+    const estimatedFeeAmount = lockedLP[1].mul(donationShare).div(bn('100'));
+    const lpBalanceAfterClaim = await uniswapPair.balanceOf(owner.address);
+
+    assert.strictEqual(holder, owner.address);
+    assert.isTrue(claimed);
+    assertBNequal(amount, lockedLP[1]);
+    assertBNequal(exitFee, estimatedFeeAmount);
+    assertBNequal(amount.sub(exitFee), lpBalanceAfterClaim.sub(lpBalanceBeforeClaim));
+
+    uniswapPairUserBalanceBefore = await uniswapPair.balanceOf(user.address);
+    uniswapPairOwnerBalanceBefore = await uniswapPair.balanceOf(owner.address);
+
+    await uniswapPair.transfer(user.address, lpBalanceAfterClaim);
+
+    uniswapPairUserBalanceAfter = await uniswapPair.balanceOf(user.address);
+    uniswapPairOwnerBalanceAfter = await uniswapPair.balanceOf(owner.address);
+
+    assertBNequal(uniswapPairUserBalanceBefore, 0);
+    assertBNequal(uniswapPairOwnerBalanceAfter, 0);
+
+    await uniswapPair.approve(uniswapRouter.address, lpBalanceAfterClaim);
+    await expect(uniswapRouter.removeLiquidity(
+      infinity.address,
+      weth.address,
+      lpBalanceAfterClaim,
+      0,
+      0,
+      owner.address,
+      new Date().getTime() + 3000,
+    )).to.be.revertedWith('revert ds-math-sub-underflow');
+
+    const infinityBalanceBefore = await infinity.balanceOf(user.address);
+    const ethUserBalanceBefore = await ethers.provider.getBalance(user.address);
+
+    await uniswapPair.connect(user).approve(uniswapRouter.address, lpBalanceAfterClaim);
+    await expect(uniswapRouter.connect(user).removeLiquidityETH(
+      infinity.address, 
+      lpBalanceAfterClaim, 
+      0, 
+      0, 
+      user.address, 
+      new Date().getTime() + 3000,
+    )).to.emit(uniswapPair, 'Burn');
+
+    const infinityBalanceAfter = await infinity.balanceOf(owner.address);
+    const ethUserBalanceAfter = await ethers.provider.getBalance(user.address);
+    
+    assert.isTrue(infinityBalanceAfter.gt(infinityBalanceBefore));
+    assert.isTrue(ethUserBalanceAfter.gt(ethUserBalanceBefore));
+
+    const lpBalanceAfterRemoveLiquidity = await uniswapPair.balanceOf(owner.address);
+
+    assertBNequal(lpBalanceAfterRemoveLiquidity, 0);
   });
 
   //TODO: add tests for the force unlock and for token with fees


### PR DESCRIPTION
Please review the current branch with end to end test for liquid vault:
'should be able to claim 1 batch after 1 purchase with 0% fees and remove liquidity from uniswap'.

Thanks in advance.